### PR TITLE
adjust package name so  matches directory structure

### DIFF
--- a/src/main/java/com/fastdtw/examples/DTWQueryTest.java
+++ b/src/main/java/com/fastdtw/examples/DTWQueryTest.java
@@ -5,7 +5,7 @@
  * stansalvador@hotmail.com
  */
 
-package com;
+package com.fastdtw.examples;
 
 import com.fastdtw.dtw.FastDTW;
 import com.fastdtw.timeseries.TimeSeries;


### PR DESCRIPTION
`DTWQueryTest` has a package name of `com` but should be `com.fastdtw.examples`
